### PR TITLE
Add initial IR spectra processing toolkit

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,84 @@
+"""Simple command line interface for spectra operations."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List
+
+import numpy as np
+
+from spectra.io import load_spectra, Spectrum
+from spectra.processing import correct_baseline, average_spectra, subtract_spectra
+from spectra.peaks import detect_peaks
+
+
+def save_spectrum(spec: Spectrum, path: str | Path) -> None:
+    data = np.column_stack([spec.x, spec.y])
+    np.savetxt(path, data)
+
+
+def cmd_baseline(args: argparse.Namespace) -> None:
+    spec = load_spectra([args.input])[0]
+    corrected = correct_baseline(spec)
+    save_spectrum(corrected, args.output)
+
+
+def cmd_average(args: argparse.Namespace) -> None:
+    specs = load_spectra(args.inputs)
+    avg = average_spectra(specs)
+    save_spectrum(avg, args.output)
+
+
+def cmd_subtract(args: argparse.Namespace) -> None:
+    spec_a, spec_b = load_spectra([args.a, args.b])
+    result = subtract_spectra(spec_a, spec_b)
+    save_spectrum(result, args.output)
+
+
+def cmd_peaks(args: argparse.Namespace) -> None:
+    spec = load_spectra([args.input])[0]
+    peaks = detect_peaks(spec, height=args.height, prominence=args.prominence)
+    for x, y in peaks:
+        print(f"{x}\t{y}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="IR spectra processing toolkit")
+    sub = parser.add_subparsers()
+
+    p_base = sub.add_parser("baseline", help="Baseline correction of a spectrum")
+    p_base.add_argument("input")
+    p_base.add_argument("output")
+    p_base.set_defaults(func=cmd_baseline)
+
+    p_avg = sub.add_parser("average", help="Average multiple spectra")
+    p_avg.add_argument("inputs", nargs="+")
+    p_avg.add_argument("output")
+    p_avg.set_defaults(func=cmd_average)
+
+    p_sub = sub.add_parser("subtract", help="Subtract spectrum B from A")
+    p_sub.add_argument("a")
+    p_sub.add_argument("b")
+    p_sub.add_argument("output")
+    p_sub.set_defaults(func=cmd_subtract)
+
+    p_peaks = sub.add_parser("peaks", help="Detect peaks in a spectrum")
+    p_peaks.add_argument("input")
+    p_peaks.add_argument("--height", type=float, default=None)
+    p_peaks.add_argument("--prominence", type=float, default=None)
+    p_peaks.set_defaults(func=cmd_peaks)
+
+    return parser
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/spectra/__init__.py
+++ b/spectra/__init__.py
@@ -1,0 +1,3 @@
+"""Basic package for IR spectra processing."""
+
+__all__ = []

--- a/spectra/io.py
+++ b/spectra/io.py
@@ -1,0 +1,49 @@
+"""Input/output utilities for IR spectra."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Tuple
+import numpy as np
+
+try:
+    from wdfreader import WdfReader  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    WdfReader = None  # type: ignore
+
+
+@dataclass
+class Spectrum:
+    x: np.ndarray
+    y: np.ndarray
+    label: str = ""
+
+
+def read_txt(path: str | Path) -> Spectrum:
+    """Read a simple two-column TXT spectrum file."""
+    data = np.loadtxt(path)
+    return Spectrum(x=data[:, 0], y=data[:, 1], label=Path(path).stem)
+
+
+def read_wdf(path: str | Path) -> Spectrum:
+    """Read a Renishaw WDF file if ``wdfreader`` is available."""
+    if WdfReader is None:
+        raise ImportError("wdfreader is required to read WDF files")
+    reader = WdfReader(str(path))
+    x = reader.xdata
+    y = reader.ydata
+    return Spectrum(x=x, y=y, label=Path(path).stem)
+
+
+def load_spectra(paths: List[str | Path]) -> List[Spectrum]:
+    """Load spectra from given file paths guessing format by suffix."""
+    spectra: List[Spectrum] = []
+    for p in paths:
+        p = Path(p)
+        if p.suffix.lower() == ".txt":
+            spectra.append(read_txt(p))
+        elif p.suffix.lower() == ".wdf":
+            spectra.append(read_wdf(p))
+        else:
+            raise ValueError(f"Unsupported spectrum format: {p.suffix}")
+    return spectra

--- a/spectra/peaks.py
+++ b/spectra/peaks.py
@@ -1,0 +1,14 @@
+"""Peak detection utilities."""
+from __future__ import annotations
+
+from typing import List, Tuple
+import numpy as np
+from scipy.signal import find_peaks
+
+from .io import Spectrum
+
+
+def detect_peaks(spec: Spectrum, height: float | None = None, prominence: float | None = None) -> List[Tuple[float, float]]:
+    """Detect peaks returning list of (x, y) tuples."""
+    idx, props = find_peaks(spec.y, height=height, prominence=prominence)
+    return list(zip(spec.x[idx], spec.y[idx]))

--- a/spectra/processing.py
+++ b/spectra/processing.py
@@ -1,0 +1,46 @@
+"""Signal processing operations for spectra."""
+from __future__ import annotations
+
+from typing import Iterable
+import numpy as np
+from scipy import sparse
+from scipy.sparse.linalg import spsolve
+
+from .io import Spectrum
+
+
+def baseline_als(y: np.ndarray, lam: float = 1e5, p: float = 0.01, niter: int = 10) -> np.ndarray:
+    """Asymmetric least squares baseline correction."""
+    L = len(y)
+    D = sparse.diags([1, -2, 1], [0, -1, -2], shape=(L - 2, L))
+    w = np.ones(L)
+    for _ in range(niter):
+        W = sparse.diags(w, 0, shape=(L, L))
+        Z = W + lam * D.T @ D
+        z = spsolve(Z, w * y)
+        w = p * (y > z) + (1 - p) * (y < z)
+    return z
+
+
+def correct_baseline(spec: Spectrum, **kwargs) -> Spectrum:
+    """Return a new spectrum with baseline subtracted."""
+    base = baseline_als(spec.y, **kwargs)
+    return Spectrum(x=spec.x.copy(), y=spec.y - base, label=spec.label)
+
+
+def average_spectra(spectra: Iterable[Spectrum]) -> Spectrum:
+    """Average spectra after interpolating to common x-axis."""
+    spectra = list(spectra)
+    if not spectra:
+        raise ValueError("No spectra provided")
+    x_common = spectra[0].x
+    ys = [np.interp(x_common, s.x, s.y) for s in spectra]
+    mean_y = np.mean(ys, axis=0)
+    return Spectrum(x=x_common, y=mean_y, label="average")
+
+
+def subtract_spectra(spec_a: Spectrum, spec_b: Spectrum) -> Spectrum:
+    """Subtract ``spec_b`` from ``spec_a`` after interpolation."""
+    x_common = spec_a.x
+    y_b = np.interp(x_common, spec_b.x, spec_b.y)
+    return Spectrum(x=x_common, y=spec_a.y - y_b, label=f"{spec_a.label}-{spec_b.label}")


### PR DESCRIPTION
## Summary
- add `Spectrum` dataclass with TXT/WDF readers and loader helpers
- implement baseline correction, averaging, subtraction, and peak detection helpers
- expose a simple CLI for baseline, averaging, subtraction, and peak picking

## Testing
- `python -m py_compile main.py spectra/*.py`
- `python main.py baseline spec1.txt corrected.txt`
- `python main.py average spec1.txt spec2.txt avg.txt`
- `python main.py peaks spec1.txt --height 0.5`
- `python main.py subtract spec1.txt spec2.txt sub.txt`


------
https://chatgpt.com/codex/tasks/task_e_68979ceea6f08325ae0896ebbb9d6b04